### PR TITLE
Support the masking of Vary header values

### DIFF
--- a/httpcache_test.go
+++ b/httpcache_test.go
@@ -1570,3 +1570,20 @@ func TestTransportVaryMatchesWithMask(t *testing.T) {
 		}
 	}
 }
+
+func TestWithVaryIgnoreMask(t *testing.T) {
+	resetTest()
+	transport := NewTransport(NewMemoryCache())
+
+	headers := []string{"header1", "header2", "header3"}
+	WithVaryIgnoreMask(headers...)(transport)
+
+	switch {
+	case !transport.VaryIgnoreMask["Header1"]:
+		fallthrough
+	case !transport.VaryIgnoreMask["Header2"]:
+		fallthrough
+	case !transport.VaryIgnoreMask["Header3"]:
+		t.Fatalf(`Headers improperly added to mask: %v`, transport.VaryIgnoreMask)
+	}
+}


### PR DESCRIPTION
This PR adds support for the masking of values in Vary headers. In this context, masking means that even if the header identified in "Vary" has changed since the response has been cached the returned response will still be cached.

This supports a very specific use-case regarding changing Authorization headers which are still desired to be cached.

TEST=unit